### PR TITLE
fix: testing a mingo workaround

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -182,11 +182,18 @@ async function readAsset (reporter, definition, id, name, encoding, req) {
     const nameQ = {
       name: assetName
     }
+    // Make a mingo compatible query
+    const nameQMingo = {
+      name: assetName
+    }
 
     if (folder) {
       nameQ.folder = {
         shortid: folder.shortid
       }
+      
+      nameQMingo['folder.shortid'] = folder.shortid
+
     } else if (
       !folder &&
       ((name.startsWith('/') && pathParts.length === 1) ||
@@ -198,6 +205,7 @@ async function readAsset (reporter, definition, id, name, encoding, req) {
     const folderQuery = {
       $or: [
         nameQ,
+        nameQMingo,
         {
           link: name
         }


### PR DESCRIPTION
Hi. I was having an issue using jsreport-core with the in memory fs. I traced the problem to a mingo query. 

```
   <img src="{#asset images/logo.png @encoding=dataURI}" width="180" class="logo"/>
```

When loading the asset from a folder, the query includes:

```
folder: {shortid: ''}
```

I assume this syntax works fine with Mongo, but it doesn't seem to work with Mingo. Or there's a deeper root issue that I'm not seeing yet. I coded this workaround in a fork so you could see the `fix`. 

```
'folder.shortid': ''
```
The workaround does not nest the object.

I just referenced this in my code and it does work now. I recognize that the code is ugly and not probably what you want to merge. If you have some thoughts and can guide me I would be happy to clean this up to make for a better PR.